### PR TITLE
Use POST for authentication

### DIFF
--- a/src/Servant/API/Auth/Token.hs
+++ b/src/Servant/API/Auth/Token.hs
@@ -474,6 +474,7 @@ type AuthSigninMethod = "auth" :> "signin"
   :> QueryParam "password" Password
   :> QueryParam "expire" Seconds
   :> Get '[JSON] (OnlyField "token" SimpleToken)
+{-# DEPRECATED AuthSigninMethod "AuthSigninPostMethod is more secure" #-}
 
 -- | How to get a token, expire of 'Nothing' means
 -- some default value (server config).

--- a/src/Servant/API/Auth/Token.hs
+++ b/src/Servant/API/Auth/Token.hs
@@ -22,6 +22,7 @@ module Servant.API.Auth.Token(
   -- * API specs
     AuthAPI
   , AuthSigninMethod
+  , AuthSigninPostMethod
   , AuthSigninGetCodeMethod
   , AuthSigninPostCodeMethod
   , AuthTouchMethod
@@ -425,6 +426,7 @@ instance ToCapture (Capture "group-id" UserGroupId) where
 -- | Generic authorization API
 type AuthAPI =
        AuthSigninMethod
+  :<|> AuthSigninPostMethod
   :<|> AuthSigninGetCodeMethod
   :<|> AuthSigninPostCodeMethod
   :<|> AuthTouchMethod
@@ -472,6 +474,31 @@ type AuthSigninMethod = "auth" :> "signin"
   :> QueryParam "password" Password
   :> QueryParam "expire" Seconds
   :> Get '[JSON] (OnlyField "token" SimpleToken)
+
+-- | How to get a token, expire of 'Nothing' means
+-- some default value (server config).
+--
+-- Logic of authorisation via this method is:
+--
+-- * Client sends POST request to the endpoint with
+-- user specified login and password and optional expire
+--
+-- * Server responds with token or error
+--
+-- * Client uses the token with other requests as authorisation
+-- header
+--
+-- * Client can extend lifetime of token by periodically pinging
+-- of 'AuthTouchMethod' endpoint
+--
+-- * Client can invalidate token instantly by 'AuthSignoutMethod'
+--
+-- * Client can get info about user with 'AuthTokenInfoMethod' endpoint.
+type AuthSigninPostMethod = "auth" :> "signin"
+  :> QueryParam "login" Login
+  :> QueryParam "password" Password
+  :> QueryParam "expire" Seconds
+  :> Post '[JSON] (OnlyField "token" SimpleToken)
 
 -- | Authorisation via code of single usage.
 --


### PR DESCRIPTION
Two options how this can be treated (note that `ServerT AuthSigninPostMethod m ~ ServerT AuthSigninMethod m`):

1. Keep this as-is, which requires changing servant-auth-token , so `authSignin` is used twice; optionally once under an alias to add an extra deprecation warning there; clients remain un-changed.

2. Remove `AuthSigninMethod`, in which case servant-auth-token remains un-changed.  (All clients will however have to be changed)